### PR TITLE
HUGO_VERSIONはvercelの環境変数で指定

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,0 @@
-{
-  "build": {
-    "env": {
-      "HUGO_VERSION": "0.76.5"
-    }
-  }
-}


### PR DESCRIPTION
- vercelの環境変数の設定で、HUGO_VERSIONを0.108.0に設定
- 参考：https://github.com/gohugoio/hugo/releases/tag/v0.108.0